### PR TITLE
[Feature] Half edge mesh extract

### DIFF
--- a/src/mesh/common.rs
+++ b/src/mesh/common.rs
@@ -38,6 +38,12 @@ impl std::ops::IndexMut<usize> for Vertex {
     }
 }
 
+impl From<Vector3> for Vertex {
+    fn from(value: Vector3) -> Vertex {
+        Vertex::new(value[0], value[1], value[2])
+    }
+}
+
 impl Into<Vector3> for Vertex {
     fn into(self) -> Vector3 {
         Vector3::new(self.x, self.y, self.z)

--- a/src/mesh/half_edge.rs
+++ b/src/mesh/half_edge.rs
@@ -332,8 +332,48 @@ impl HeMesh {
 
     /// Extract a subset from the mesh by the index of the face. This
     /// copies the target subset into a new mesh.
-    pub fn extract_faces(&self, _faces: &Vec<usize>) -> HeMesh {
-        unimplemented!()
+    pub fn extract_faces(&self, face_ids: &Vec<usize>) -> HeMesh {
+        let mut faces = Vec::<Face>::with_capacity(face_ids.len());
+        let mut vertices = vec![];
+        let mut patches = vec![];
+        let mut index_vertices = HashMap::new();
+        let mut index_patches = HashMap::new();
+
+        for &face_id in face_ids.iter() {
+            let mut vertices_ = self.face_vertices(face_id);
+            let mut patch_ = None;
+
+            for old_id in vertices_.iter_mut() {
+                if !index_vertices.contains_key(old_id) {
+                    let new_id = index_vertices.len();
+                    index_vertices.insert(*old_id, new_id);
+
+                    let point = self.vertices[*old_id].point;
+                    let vertex = Vertex::from(point);
+                    vertices.push(vertex);
+                }
+
+                *old_id = index_vertices[old_id];
+            }
+
+            if let Some(old_id) = self.faces[face_id].patch {
+                if !index_patches.contains_key(&old_id) {
+                    let new_id = index_patches.len();
+                    index_patches.insert(old_id, new_id);
+
+                    let name = self.patches[old_id].name().to_string();
+                    let patch = Patch::new(name);
+                    patches.push(patch);
+                }
+
+                patch_ = Some(index_patches[&old_id]);
+            }
+
+            let face = Face::new(vertices_, patch_);
+            faces.push(face);
+        }
+
+        HeMesh::new(&vertices, &faces, &patches)
     }
 
     /// Extract a subset from the mesh by the patch names. This copies the
@@ -564,7 +604,6 @@ mod test {
         let mesh = HeMesh::from_obj(&path).unwrap();
 
         let neighbors = mesh.vertex_neighbors(1);
-        dbg!(&neighbors);
 
         assert_eq!(neighbors.len(), 5);
         assert_eq!(neighbors[0], 3);
@@ -689,10 +728,11 @@ mod test {
 
         let patches: Vec<&str> = vec!["front", "right"];
         let mesh2 = mesh1.extract_patches(&patches);
+        dbg!(&mesh2);
 
-        assert_eq!(mesh2.n_vertices(), 5);
-        assert_eq!(mesh2.n_faces(), 3);
-        assert_eq!(mesh2.n_half_edges(), 9);
+        assert_eq!(mesh2.n_vertices(), 6);
+        assert_eq!(mesh2.n_faces(), 4);
+        assert_eq!(mesh2.n_half_edges(), 12);
         assert_eq!(mesh2.n_patches(), 2);
     }
 }

--- a/src/mesh/half_edge.rs
+++ b/src/mesh/half_edge.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::geometry::Vector3;
 use crate::mesh::wavefront::ObjReader;
@@ -250,6 +250,40 @@ impl HeMesh {
 
         self.patches = patches;
     }
+
+    /// Extract a subset from the mesh by the index of the face. This
+    /// copies the target subset into a new mesh.
+    pub fn extract_faces(&self, faces: &Vec<usize>) -> HeMesh {
+        unimplemented!()
+    }
+
+    /// Extract a subset from the mesh by the patch names. This copies the
+    /// target subset into a new mesh.
+    pub fn extract_patches(&self, patches: &Vec<&str>) -> HeMesh {
+        let mut selected = HashSet::new();
+        let mut index = vec![false; self.n_patches()];
+        let mut faces = vec![];
+
+        for patch in patches.iter() {
+            selected.insert(patch.clone());
+        }
+
+        for (i, patch) in self.patches.iter().enumerate() {
+            if selected.contains(patch.name()) {
+                index[i] = true;
+            }
+        }
+
+        for (i, face) in self.faces.iter().enumerate() {
+            if let Some(patch) = face.patch {
+                if index[patch] {
+                    faces.push(i);
+                }
+            }
+        }
+
+        self.extract_faces(&faces)
+    }
 }
 
 #[derive(Debug, Copy, Clone, Default)]
@@ -475,5 +509,33 @@ mod test {
         mesh1.combine_patches();
 
         assert_eq!(mesh1.n_patches(), 6);
+    }
+
+    #[test]
+    fn test_extract_faces() {
+        let path = "tests/fixtures/box_groups.obj";
+        let mesh1 = HeMesh::from_obj(&path).unwrap();
+
+        let faces = vec![0, 1, 6];
+        let mesh2 = mesh1.extract_faces(&faces);
+
+        assert_eq!(mesh2.n_vertices(), 5);
+        assert_eq!(mesh2.n_faces(), 3);
+        assert_eq!(mesh2.n_half_edges(), 9);
+        assert_eq!(mesh2.n_patches(), 2);
+    }
+
+    #[test]
+    fn test_extract_patches() {
+        let path = "tests/fixtures/box_groups.obj";
+        let mesh1 = HeMesh::from_obj(&path).unwrap();
+
+        let patches: Vec<&str> = vec!["front", "right"];
+        let mesh2 = mesh1.extract_patches(&patches);
+
+        assert_eq!(mesh2.n_vertices(), 5);
+        assert_eq!(mesh2.n_faces(), 3);
+        assert_eq!(mesh2.n_half_edges(), 9);
+        assert_eq!(mesh2.n_patches(), 2);
     }
 }

--- a/src/mesh/half_edge.rs
+++ b/src/mesh/half_edge.rs
@@ -37,19 +37,18 @@ impl HeMesh {
             let count = mesh.half_edges.len();
             let n = face.vertices().len();
 
+            let mut next_offset = (0..n).collect::<Vec<usize>>();
+            let mut prev_offset = (0..n).collect::<Vec<usize>>();
+            next_offset.rotate_left(1);
+            prev_offset.rotate_right(1);
+
             for (edge_id, edge) in face.edges().iter().enumerate() {
                 let half_edge_id = count + edge_id;
                 let mut half_edge = HeHalfEdge::default();
                 half_edge.origin = edge[0];
                 half_edge.face = face_id;
-
-                if edge_id == 0 {
-                    half_edge.prev = count + n - 1;
-                    half_edge.next = count + edge_id + 1;
-                } else {
-                    half_edge.prev = count + edge_id - 1;
-                    half_edge.next = count;
-                }
+                half_edge.prev = count + prev_offset[edge_id];
+                half_edge.next = count + next_offset[edge_id];
 
                 // Insert the half edge and update the originating half edge
                 // for the origin (vertex).
@@ -182,6 +181,86 @@ impl HeMesh {
         true
     }
 
+    /// Compute the neighboring vertices for a vertex by index. This is only
+    /// valid for closed oriented meshes.
+    pub fn vertex_neighbors(&self, index: usize) -> Vec<usize> {
+        let vertex = self.vertices[index];
+        let mut current = vertex.half_edge;
+        let mut neighbors = vec![];
+
+        loop {
+            let half_edge = self.half_edges[current];
+            let prev = self.half_edges[half_edge.prev];
+            neighbors.push(prev.origin);
+
+            current = prev.twin.expect("mesh must be closed");
+
+            if current == vertex.half_edge {
+                break;
+            }
+        }
+
+        neighbors
+    }
+
+    /// Compute the faces containing a vertex by index. This is only valid
+    /// for closed oriented meshes.
+    pub fn vertex_faces(&self, index: usize) -> Vec<usize> {
+        let vertex = self.vertices[index];
+        let mut current = vertex.half_edge;
+        let mut faces = vec![];
+
+        loop {
+            let half_edge = self.half_edges[current];
+            faces.push(half_edge.face);
+
+            let prev = self.half_edges[half_edge.prev];
+            current = prev.twin.expect("mesh must be closed");
+
+            if current == vertex.half_edge {
+                break;
+            }
+        }
+
+        faces
+    }
+
+    /// Compute the vertices defining a face by index
+    pub fn face_vertices(&self, index: usize) -> Vec<usize> {
+        self.face_half_edges(index)
+            .iter()
+            .map(|&i| self.half_edges[i].origin)
+            .collect()
+    }
+
+    /// Compute the neighboring faces for a face by index
+    pub fn face_neighbors(&self, index: usize) -> Vec<usize> {
+        self.face_half_edges(index)
+            .iter()
+            .map(|&i| self.half_edges[i])
+            .filter(|h| !h.is_boundary())
+            .map(|h| self.half_edges[h.twin.unwrap()].face)
+            .collect()
+    }
+
+    /// Compute the ordered half edges defining the boundary of a face by index
+    pub fn face_half_edges(&self, index: usize) -> Vec<usize> {
+        let face = self.faces[index];
+        let mut current = face.half_edge;
+        let mut half_edges = vec![];
+
+        loop {
+            half_edges.push(current);
+            current = self.half_edges[current].next;
+
+            if current == face.half_edge {
+                break;
+            }
+        }
+
+        half_edges
+    }
+
     /// Merge the mesh into the current mesh naively. This strictly copies
     /// the mesh and does not merge vertices, edges, or faces.
     pub fn merge(&mut self, other: &HeMesh) {
@@ -253,7 +332,7 @@ impl HeMesh {
 
     /// Extract a subset from the mesh by the index of the face. This
     /// copies the target subset into a new mesh.
-    pub fn extract_faces(&self, faces: &Vec<usize>) -> HeMesh {
+    pub fn extract_faces(&self, _faces: &Vec<usize>) -> HeMesh {
         unimplemented!()
     }
 
@@ -265,7 +344,7 @@ impl HeMesh {
         let mut faces = vec![];
 
         for patch in patches.iter() {
-            selected.insert(patch.clone());
+            selected.insert(patch.to_string());
         }
 
         for (i, patch) in self.patches.iter().enumerate() {
@@ -477,6 +556,84 @@ mod test {
         let mesh = HeMesh::from_obj(&path).unwrap();
 
         assert!(!mesh.is_consistent());
+    }
+
+    #[test]
+    fn test_vertex_neighbors() {
+        let path = "tests/fixtures/box.obj";
+        let mesh = HeMesh::from_obj(&path).unwrap();
+
+        let neighbors = mesh.vertex_neighbors(1);
+        dbg!(&neighbors);
+
+        assert_eq!(neighbors.len(), 5);
+        assert_eq!(neighbors[0], 3);
+        assert_eq!(neighbors[1], 2);
+        assert_eq!(neighbors[2], 0);
+        assert_eq!(neighbors[3], 4);
+        assert_eq!(neighbors[4], 5);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_vertex_neighbors_inverted() {
+        // TODO: implement
+    }
+
+    #[test]
+    fn test_vertex_faces() {
+        let path = "tests/fixtures/box.obj";
+        let mesh = HeMesh::from_obj(&path).unwrap();
+
+        let faces = mesh.vertex_faces(1);
+
+        assert_eq!(faces.len(), 5);
+        assert_eq!(faces[0], 10);
+        assert_eq!(faces[1], 1);
+        assert_eq!(faces[2], 0);
+        assert_eq!(faces[3], 4);
+        assert_eq!(faces[4], 5);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_vertex_faces_inverted() {
+        // TODO: implement
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_vertex_faces_open() {
+        let path = "tests/fixtures/box_open.obj";
+        let mesh = HeMesh::from_obj(&path).unwrap();
+
+        mesh.vertex_faces(2);
+    }
+
+    #[test]
+    fn test_face_neighbors() {
+        let path = "tests/fixtures/box.obj";
+        let mesh = HeMesh::from_obj(&path).unwrap();
+
+        let neighbors = mesh.face_neighbors(1);
+
+        assert_eq!(neighbors.len(), 3);
+        assert_eq!(neighbors[0], 10);
+        assert_eq!(neighbors[1], 6);
+        assert_eq!(neighbors[2], 0);
+    }
+
+    #[test]
+    fn test_face_half_edges() {
+        let path = "tests/fixtures/box.obj";
+        let mesh = HeMesh::from_obj(&path).unwrap();
+
+        let half_edges = mesh.face_half_edges(1);
+
+        assert_eq!(half_edges.len(), 3);
+        assert_eq!(mesh.half_edge(half_edges[0]).origin, 1);
+        assert_eq!(mesh.half_edge(half_edges[1]).origin, 3);
+        assert_eq!(mesh.half_edge(half_edges[2]).origin, 2);
     }
 
     #[test]


### PR DESCRIPTION
Adds the following methods for the half edge mesh:
- `extract_faces` to extract a subset of the mesh by face indices
- `extract_patches` to extract a subset of the mesh by patch names